### PR TITLE
Add Enhanced Monitoring

### DIFF
--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -96,11 +96,11 @@ export default {
                                 cf.join(['arn:aws:s3:::', cf.ref('TileBaseS3')]),
                                 cf.join(['arn:aws:s3:::', cf.ref('TileBaseS3'), '/*'])
                             ],
-                            Action: [ "s3:Get*", "s3:List*" ]
+                            Action: ['s3:Get*', 's3:List*']
 
                         }]
                     }
-                }],
+                }]
             }
         },
         ExecRole: {

--- a/cloudformation/lib/db.js
+++ b/cloudformation/lib/db.js
@@ -35,12 +35,34 @@ export default {
                 TargetType: 'AWS::RDS::DBInstance'
             }
         },
+        DBMonitoringRole: {
+            Type: 'AWS::IAM::Role',
+            Properties: {
+                AssumeRolePolicyDocument: {
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Sid: '',
+                        Effect: 'Allow',
+                        Principal: {
+                            Service: 'monitoring.rds.amazonaws.com'
+                        },
+                        Action: 'sts:AssumeRole'
+                    }]
+                },
+                ManagedPolicyArns: [
+                    'arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole'
+                ],
+                Path: '/'
+            }
+        },
         DBInstance: {
             Type: 'AWS::RDS::DBInstance',
             DependsOn: ['DBMasterSecret'],
             Properties: {
                 Engine: 'postgres',
                 DBName: 'tak_ps_stats',
+                MonitoringInterval: 60,
+                MonitoringRoleArn: cf.getAtt('DBMonitoringRole', 'Arn'),
                 DBInstanceIdentifier: cf.stackName,
                 KmsKeyId: cf.ref('KMS'),
                 EngineVersion: '14.5',


### PR DESCRIPTION
### Context

Lack of Enhanced Monitoring on our RDS Instances resulted in them being terminated until monitoring was added.
